### PR TITLE
chore: add docker-compose stack with app and postgres

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,11 +1,15 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./todo.db"
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./todo.db")
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+connect_args = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args = {"check_same_thread": False}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    container_name: task_db
+    environment:
+      POSTGRES_USER: taskuser
+      POSTGRES_PASSWORD: taskpass
+      POSTGRES_DB: taskdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  api:
+    build: .
+    container_name: task_api
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgresql://taskuser:taskpass@db:5432/taskdb
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## ✨ What’s inside

This PR introduces a local Docker stack with PostgreSQL using `docker-compose`.

### Changes
- Added `docker-compose.yml` with:
  - FastAPI app service
  - PostgreSQL service
- Database configuration now supports `DATABASE_URL` via environment variables
- SQLite remains the default fallback for local non-docker runs

### Why
This prepares the project for:
- running the app with a real database (Postgres),
- future migration away from SQLite,
- upcoming CI/database integration steps.

No application logic was changed.